### PR TITLE
feat: GitHub Actions CIワークフローを追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,14 +26,5 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      # - name: Run ESLint
-      #   run: npm run lint:check
-
-      # - name: Check Prettier formatting
-      #   run: npm run format:check
-
-      # - name: Run tests
-      #   run: npm test
-
       - name: Run build
         run: npm run build


### PR DESCRIPTION
## Summary
- GitHub Actions CIワークフローを追加
- buildチェックのみを実行する軽量なCI設定
- Node.js 22でマトリックステスト

## Test plan
- [x] CIワークフローが正常に動作することを確認
- [x] buildが通ることを確認