### PR TITLE
fix: 3Dモデルの位置・サイズ調整と定数化

### DIFF
--- a/src/components/common/3DComponent/BaseballStadium.tsx
+++ b/src/components/common/3DComponent/BaseballStadium.tsx
@@ -5,6 +5,7 @@ import { Vector3, Euler } from 'three';
 import { GLBModel } from '@/components/common/GLBModel';
 import { ErrorBoundary } from '@/components/common/3DComponent/ErrorBoundary';
 import { ModelConfig } from '@/types/modelConfig';
+import { MODEL_CONFIG } from '@/constants/ModelPosition';
 
 export interface BaseballStadiumProps extends ModelConfig {
   onLoad?: () => void;
@@ -13,9 +14,9 @@ export interface BaseballStadiumProps extends ModelConfig {
 }
 
 const BaseballStadium: React.FC<BaseballStadiumProps> = ({
-  position = new Vector3(0, -10, 0),
-  rotation = new Euler(0, 0, 0),
-  scale = 1,
+  position = MODEL_CONFIG.STADIUM.position,
+  rotation = MODEL_CONFIG.STADIUM.rotation,
+  scale = MODEL_CONFIG.STADIUM.scale,
   modelPath = "/models/BaseballStadium.glb",
   visible = true,
   onLoad,

--- a/src/components/future/modelTest/Scene.tsx
+++ b/src/components/future/modelTest/Scene.tsx
@@ -7,18 +7,19 @@ import { Vector3, Euler } from 'three';
 import { ErrorBoundary } from '@/components/common/3DComponent/ErrorBoundary';
 import BaseballStadium from '@/components/common/3DComponent/BaseballStadium';
 import { BatController } from '@/components/common/3DComponent/BatController';
+import { MODEL_CONFIG } from '@/constants/ModelPosition';
 
 interface SceneProps {
   debugMode?: boolean;
 }
 
 export const Scene: React.FC<SceneProps> = ({ debugMode = false }) => {
-  const [stadiumScale, setStadiumScale] = useState<number>(1);
-  const [stadiumPosition, setStadiumPosition] = useState<Vector3>(new Vector3(0, -10, 0));
-  const [stadiumRotation, setStadiumRotation] = useState<Euler>(new Euler(0, 0, 0));
-  
-  const [batScale, setBatScale] = useState<number>(1);
-  const [batPosition, setBatPosition] = useState<Vector3>(new Vector3(0, 0, 0));
+  const [stadiumScale, setStadiumScale] = useState<number>(MODEL_CONFIG.STADIUM.scale);
+  const [stadiumPosition, setStadiumPosition] = useState<Vector3>(MODEL_CONFIG.STADIUM.position);
+  const [stadiumRotation, setStadiumRotation] = useState<Euler>(MODEL_CONFIG.STADIUM.rotation);
+
+  const [batScale, setBatScale] = useState<number>(MODEL_CONFIG.BAT.scale);
+  const [batPosition, setBatPosition] = useState<Vector3>(MODEL_CONFIG.BAT.position);
 
   // Define start and end rotations for the bat swing
   const startRotation = new Euler(-13 * Math.PI / 180, 0, 13 * Math.PI / 180);

--- a/src/constants/ModelPosition.ts
+++ b/src/constants/ModelPosition.ts
@@ -1,0 +1,46 @@
+// モデルの初期位置
+
+// 野球盤のモデル
+const StadiumModelPosition = {
+  x: 0,
+  y: 0,
+  z: 0
+};
+
+// モデルのスケール
+const StadiumModelScale = 1;
+
+// モデルの回転
+const StadiumModelRotation = {
+  x: 0,
+  y: 0,
+  z: 0
+};
+
+// バットのモデル
+const BatModelPosition = {
+  x: 0,
+  y: 0,
+  z: 0
+};
+
+const BatModelRotation = {
+  x: 0,
+  y: 0,
+  z: 0
+};
+
+const BatModelScale = 1;
+
+// ボールのモデル
+const BallModelScale = 1;
+
+export {
+  StadiumModelPosition,
+  StadiumModelScale,
+  StadiumModelRotation,
+  BatModelPosition,
+  BatModelRotation,
+  BatModelScale,
+  BallModelScale
+};

--- a/src/constants/ModelPosition.ts
+++ b/src/constants/ModelPosition.ts
@@ -1,46 +1,20 @@
-// モデルの初期位置
+import { Vector3, Euler } from 'three';
 
-// 野球盤のモデル
-const StadiumModelPosition = {
-  x: 0,
-  y: 0,
-  z: 0
-};
-
-// モデルのスケール
-const StadiumModelScale = 1;
-
-// モデルの回転
-const StadiumModelRotation = {
-  x: 0,
-  y: 0,
-  z: 0
-};
-
-// バットのモデル
-const BatModelPosition = {
-  x: 0,
-  y: 0,
-  z: 0
-};
-
-const BatModelRotation = {
-  x: 0,
-  y: 0,
-  z: 0
-};
-
-const BatModelScale = 1;
-
-// ボールのモデル
-const BallModelScale = 1;
-
-export {
-  StadiumModelPosition,
-  StadiumModelScale,
-  StadiumModelRotation,
-  BatModelPosition,
-  BatModelRotation,
-  BatModelScale,
-  BallModelScale
-};
+// 3Dモデルの設定定数
+export const MODEL_CONFIG = {
+  STADIUM: {
+    position: new Vector3(0, -1, 50),
+    rotation: new Euler(0, 0, 0),
+    scale: 1
+  },
+  BAT: {
+    position: new Vector3(0, 0, 0),
+    rotation: new Euler(0, 0, 0),
+    scale: 4
+  },
+  BALL: {
+    position: new Vector3(0, 0, 0),
+    rotation: new Euler(0, 0, 0),
+    scale: 1
+  }
+} as const;

--- a/src/types/modelConfig.ts
+++ b/src/types/modelConfig.ts
@@ -8,3 +8,16 @@ export interface ModelConfig {
   visible?: boolean;
   debugMode?: boolean;
 }
+
+// モデル設定の型定義
+export interface ModelTransform {
+  x: number;
+  y: number;
+  z: number;
+}
+
+export interface ModelConfiguration {
+  position: ModelTransform;
+  rotation: ModelTransform;
+  scale: number;
+}


### PR DESCRIPTION
## Summary
• 3Dモデル（スタジアム、バット）の位置とサイズをハードコーディングから定数ファイルに移行

## 主な変更点
• `src/constants/ModelPosition.ts` - 3Dモデルの設定定数を追加

## Test plan
- [x] 3Dモデルが正しい位置とサイズで表示されることを確認