### PR TITLE
feat: バットモデルのFBX→GLB変更と回転軸の調整

### DIFF
--- a/src/components/common/3DComponent/Bat.tsx
+++ b/src/components/common/3DComponent/Bat.tsx
@@ -2,7 +2,7 @@
 
 import { useRef, Suspense, useState, useEffect } from 'react';
 import { Group, Vector3, Euler } from 'three';
-import { FBXModel } from '@/components/common/FBXModel';
+import { GLBModel } from '@/components/common/GLBModel';
 import { FallbackBat } from '@/components/common/3DComponent/FallbackBat';
 import type { DebugInfo } from '@/types/debug';
 import { ModelConfig } from '@/types/modelConfig';
@@ -17,59 +17,59 @@ export const Bat: React.FC<BatProps> = ({
   position = new Vector3(0, 0, 0),
   rotation = new Euler(0, 0, 0),
   scale = 1,
-  modelPath = "/models/bat/IronBat.fbx",
+  modelPath = "/models/BaseballBat.glb",
   visible = true,
   onLoad,
   onError,
   onDebugInfo
 }) => {
   const groupRef = useRef<Group>(null);
-  const [fbxLoaded, setFbxLoaded] = useState(false);
-  const [fbxError, setFbxError] = useState(false);
+  const [glbLoaded, setGlbLoaded] = useState(false);
+  const [glbError, setGlbError] = useState(false);
   const [loadingTimeout, setLoadingTimeout] = useState(false);
 
   // デバッグ情報を更新
   useEffect(() => {
     onDebugInfo?.({
-      fbxLoaded,
-      fbxError,
+      glbLoaded,
+      glbError,
       loadingTimeout,
       modelPath
     });
-  }, [fbxLoaded, fbxError, loadingTimeout, modelPath, onDebugInfo]);
+  }, [glbLoaded, glbError, loadingTimeout, modelPath, onDebugInfo]);
 
   // 5秒後にタイムアウトしてフォールバックを表示
   useEffect(() => {
     const timer = setTimeout(() => {
-      if (!fbxLoaded && !fbxError) {
+      if (!glbLoaded && !glbError) {
         setLoadingTimeout(true);
       }
     }, 5000);
 
     return () => clearTimeout(timer);
-  }, [fbxLoaded, fbxError]);
+  }, [glbLoaded, glbError]);
 
   const handleLoad = () => {
-    setFbxLoaded(true);
+    setGlbLoaded(true);
     onLoad?.();
   };
 
   const handleError = (error: Error) => {
-    setFbxError(true);
+    setGlbError(true);
     onError?.(error);
   };
 
   // 表示するコンテンツを決定
   const renderContent = () => {
     // エラーまたはタイムアウトの場合はフォールバック表示
-    if (fbxError || loadingTimeout) {
+    if (glbError || loadingTimeout) {
       return <FallbackBat color="#8B4513" />;
     }
     
     // 通常の読み込み試行
     return (
       <Suspense fallback={<FallbackBat color="#666666" />}>
-          <FBXModel 
+          <GLBModel 
             modelPath={modelPath}
             onLoad={handleLoad}
             onError={handleError}

--- a/src/components/common/3DComponent/Bat.tsx
+++ b/src/components/common/3DComponent/Bat.tsx
@@ -83,7 +83,7 @@ export const Bat: React.FC<BatProps> = ({
       ref={groupRef}
       position={[position.x, position.y, position.z]}
       rotation={[rotation.x, rotation.y, rotation.z]}
-      scale={[scale, scale, scale]}
+      scale={[Math.abs(scale), -Math.abs(scale), Math.abs(scale)]}
       visible={visible}
     >
       {renderContent()}

--- a/src/components/common/3DComponent/BatController.tsx
+++ b/src/components/common/3DComponent/BatController.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, forwardRef } from 'react';
 import { useFrame } from '@react-three/fiber';
-import { Euler } from 'three';
+import { Euler, Vector3 } from 'three';
 import { Bat, BatProps } from '@/components/common/3DComponent/Bat';
 
 // BatControllerが受け取るPropsの型を定義
@@ -66,7 +66,18 @@ export const BatController = forwardRef<unknown, BatControllerProps>((props, ref
     }
   });
 
-  return <Bat {...props} rotation={rotation} />;
+  return (
+    <group 
+      position={props.position ? [props.position.x, props.position.y, props.position.z] : [0, 0, 0]}
+      rotation={[rotation.x, rotation.y, rotation.z]}
+    >
+      <Bat 
+        {...props} 
+        rotation={new Euler(0, 0, 0)}
+        position={new Vector3(0, 1.3, 0)}
+      />
+    </group>
+  );
 });
 
 // displayNameを設定してデバッグしやすくする

--- a/src/components/future/modelTest/Scene.tsx
+++ b/src/components/future/modelTest/Scene.tsx
@@ -49,7 +49,7 @@ export const Scene: React.FC<SceneProps> = ({ debugMode = false }) => {
               scale={batScale}
               startRotation={startRotation}
               endRotation={endRotation}
-              modelPath="/models/bat/IronBat.fbx"
+              modelPath="/models/BaseballBat.glb"
               onLoad={() => console.log('Bat loaded')}
             />
             

--- a/src/constants/ModelPosition.ts
+++ b/src/constants/ModelPosition.ts
@@ -9,8 +9,8 @@ export const MODEL_CONFIG = {
   },
   BAT: {
     position: new Vector3(2, 1.4, 0),
-    rotation: new Euler(0, 0, 0),
-    scale: 4
+    rotation: new Euler(90, 0, 0),
+    scale: 7
   },
   BALL: {
     position: new Vector3(0, 0, 0),

--- a/src/constants/ModelPosition.ts
+++ b/src/constants/ModelPosition.ts
@@ -8,9 +8,9 @@ export const MODEL_CONFIG = {
     scale: 1
   },
   BAT: {
-    position: new Vector3(2, 1.4, 0),
+    position: new Vector3(1.4, 1.4, 0),
     rotation: new Euler(90, 0, 0),
-    scale: 7
+    scale: 10
   },
   BALL: {
     position: new Vector3(0, 0, 0),

--- a/src/types/debug.ts
+++ b/src/types/debug.ts
@@ -1,7 +1,7 @@
 // DebugInfo型を定義
 export interface DebugInfo {
-  fbxLoaded: boolean;
-  fbxError: boolean;
+  glbLoaded: boolean;
+  glbError: boolean;
   loadingTimeout: boolean;
   modelPath: string;
   // 必要に応じて追加


### PR DESCRIPTION
## Summary
- バットモデルをFBXからGLBフォーマットに変更
- バットの上下反転機能を追加
- 回転の中心軸をグリップ部分に調整
- Scene.tsxでのモデルパス修正

## 変更内容
- `Bat.tsx`: FBXModelからGLBModelに変更、Y軸スケールを反転
- `BatController.tsx`: 回転軸をグリップ中心に調整
- `Scene.tsx`: モデルパスを適切なGLBファイルに変更
- `DebugInfo` 型定義をglbフィールドに更新

## Test plan
- [ ] バットモデルが正しく読み込まれることを確認
- [ ] バットの回転がグリップ中心で行われることを確認
- [ ] スペースキーでのバットスイングが正常に動作することを確認